### PR TITLE
Update requirements.txt to non-broken versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ alpha_vantage
 pandas
 numpy
 sklearn
-keras
-tensorflow
+keras==2.2.4
+tensorflow==1.13.0rc1
 matplotlib


### PR DESCRIPTION
Apply a fix to issue #14. TensorFlow will automatically install version 2, which has a few breaking changes to the code that results in the demo code not being able to execute. keras needs to be downgraded as well to a version that supports tensorflow==1.13.0rc1.